### PR TITLE
Make stderr redirection compatible with Fish 3.0.

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -54,7 +54,7 @@ function fish_prompt
   echo -n $red'┌'$cyan$USER$white'@'$cyan$__fish_prompt_hostname $gray(prompt_pwd)$normal
   __fish_git_prompt
   # Check for gwip; does last commit log contain --wip--?
-  if begin; git log -n 1 ^/dev/null | grep -qc "\-\-wip\-\-"; end
+  if begin; git log -n 1 2> /dev/null | grep -qc "\-\-wip\-\-"; end
     echo -n $brwhite' WIP!'$normal
   end
   echo


### PR DESCRIPTION
Fish has deprecated `^` as a shortcut for stderr redirection in 3.0. Replace it with the more
compatible `2>`.

See oh-my-fish/oh-my-fish#609 and oh-my-fish/oh-my-fish#618